### PR TITLE
fix(src/modules/ux-jwt): 修复ux-jwt模块工厂函数注入ts报错

### DIFF
--- a/src/modules/ux-jwt/ux-jwt.module.ts
+++ b/src/modules/ux-jwt/ux-jwt.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { JwtModule } from '@nestjs/jwt';
+import { JwtModule, type JwtModuleOptions } from '@nestjs/jwt';
 import { UxJwtService } from './ux-jwt.service';
 import { ConfigService } from '@nestjs/config';
 import { EnvConfigModule } from '@/modules/env-config/env-config.module';
@@ -9,7 +9,7 @@ import { resolve } from 'node:path';
   imports: [
     JwtModule.registerAsync({
       imports: [EnvConfigModule],
-      useFactory: (configService: ConfigService) => {
+      useFactory: (configService: ConfigService): JwtModuleOptions => {
         const privateKeyPath = resolve(
           __dirname,
           `../../../${configService.get<string>('JWT_PRIVATEKEYPATH')!}`,
@@ -24,7 +24,7 @@ import { resolve } from 'node:path';
           privateKey,
           publicKey,
           signOptions: {
-            expiresIn: configService.get<string>('JWT_GLOBAL_EXPIRES_IN'),
+            expiresIn: configService.get('JWT_GLOBAL_EXPIRES_IN'),
             algorithm: 'RS256',
           },
         };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "target": "ES2023",
+    "target": "esnext",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",


### PR DESCRIPTION
修复ux-jwt模块工厂函数返回类型报错，使用显示声明类型JwtModuleOptions约束响应类型并删除signOptions.expiresIn在赋值时的显示类型声明导致类型无法匹配

#9